### PR TITLE
Improved errors and more unittests

### DIFF
--- a/blockyaml/__init__.py
+++ b/blockyaml/__init__.py
@@ -22,6 +22,7 @@ from .converters import (
     YAMLDataclassExtraFieldsError,
     YAMLDataclassFieldError,
     YAMLDataclassMissingFieldsError,
+    YAMLRepresenterError,
 )
 from .parsers import Parser, SimpleParser, YAMLParserError
 
@@ -32,6 +33,7 @@ assert all(
         DataclassConverter,
         types,
         YAMLConstructorError,
+        YAMLRepresenterError,
         YAMLConversionError,
         YAMLParserError,
         YAMLDataclassFieldError,

--- a/blockyaml/converters.py
+++ b/blockyaml/converters.py
@@ -33,9 +33,10 @@ if TYPE_CHECKING:
 
 try:
     from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as Loader
 except ImportError:
-    from yaml import Dumper, Loader
+    from yaml import SafeDumper as Dumper
+    from yaml import SafeLoader as Loader
 
 from .types import (
     CollectionNode,
@@ -133,12 +134,20 @@ class Converter(abc.ABC, Generic[_Convertable, _Parser]):
     def construct_node(self, loader: Loader, node: Node) -> _Convertable:
         if self._base_constructor:
             return self._base_constructor(loader, node)
-        raise NotImplementedError
+        raise YAMLConstructorError(
+            f"Converter `{type(self).__name__}` for tag `{self.tag}` doesn't"
+            f" provide a method to construct from `{type(node).__name__}`"
+            f" with value `{node.value}`.",
+            context_mark=node.start_mark,
+        )
 
     def represent_node(self, representer: Representer, value: _Convertable) -> Node:
         if self._base_representer:
             return self._base_representer(representer, value)
-        raise NotImplementedError
+        raise YAMLRepresenterError(
+            f"Converter `{type(self).__name__}` for tag `{self.tag}` doesn't"
+            f" provide a method to represent `{value}`."
+        )
 
 
 class ImplicitConverter(Converter[_Convertable, _Parser]):
@@ -163,9 +172,8 @@ class ImplicitConverter(Converter[_Convertable, _Parser]):
         if constructor := self._base_constructors.get(node.tag, None):
             return constructor(loader, node)
         raise YAMLConstructorError(
-            f"Got tag `{node.tag}` with no registered"
-            " converter. If it is meant to be a string"
-            " it requires quotes, otherwise a"
+            f"Can't construct `{node.tag}` as it has no registered converter."
+            " If it is meant to be a string, it requires quotes, otherwise a"
             " converter will need to be registered.",
             context_mark=node.start_mark,
         )
@@ -174,9 +182,8 @@ class ImplicitConverter(Converter[_Convertable, _Parser]):
         if base_representer := self._base_representers.get(type(value), None):
             return base_representer(representer, value)
         raise YAMLRepresenterError(
-            f"Got type `{type(value)}` without a"
-            " registered converter. A converter will"
-            " need to be registered."
+            f"Can't represent `{value}` as it has no registered converter."
+            " A converter will need to be registered."
         )
 
 

--- a/blockyaml/converters.py
+++ b/blockyaml/converters.py
@@ -141,10 +141,10 @@ class Converter(abc.ABC, Generic[_Convertable, _Parser]):
         raise NotImplementedError
 
 
-class PrimitiveConverter(Converter[_Convertable, _Parser]):
+class ImplicitConverter(Converter[_Convertable, _Parser]):
     """
-    Converter for primitive objects, allows for sanity checks to be
-    imposed on the data beyond standard YAML syntax.
+    Converter for values which are implicitly converted, allows for sanity
+    checks to be imposed on the data beyond standard YAML syntax.
     """
 
     def bind_loader(self, loader: type[Loader]):
@@ -181,9 +181,10 @@ class PrimitiveConverter(Converter[_Convertable, _Parser]):
 
 
 @dataclass(kw_only=True)
-class SensiblePrimitives(PrimitiveConverter[_Convertable, _Parser]):
+class StrictImplicitConverter(ImplicitConverter[_Convertable, _Parser]):
     """
-    Converter for primitive objects with sensible checking by default.
+    Converter for values which are implicitly converted, with stricter checking
+    by default.
     """
 
     strict_keys: bool = True
@@ -232,8 +233,8 @@ class ConverterRegistry:
     can be used to initialise a Parser object.
     """
 
-    def __init__(self, primitive_converter: PrimitiveConverter | None = None):
-        self._primitive_converter = primitive_converter
+    def __init__(self, implicit_converter: ImplicitConverter | None = None):
+        self._implicit_converter = implicit_converter
         self._registered_tags: set[str] = set()
         self._registered_typs: set[Any] = set()
         self._registry: list[tuple[str, Any, type[Converter]]] = []

--- a/blockyaml/parsers.py
+++ b/blockyaml/parsers.py
@@ -21,8 +21,8 @@ from yaml import dump, load
 from .converters import (
     Converter,
     ConverterRegistry,
-    PrimitiveConverter,
-    SensiblePrimitives,
+    ImplicitConverter,
+    StrictImplicitConverter,
     _Convertable,
 )
 from .types import Dumper, Loader, YAMLError
@@ -131,7 +131,7 @@ class Parser:
     def __init__(
         self,
         registry: ConverterRegistry | None = None,
-        primitive_converter: PrimitiveConverter | None = None,
+        implicit_converter: ImplicitConverter | None = None,
     ):
         class _Loader(Loader):
             ...
@@ -143,19 +143,19 @@ class Parser:
         self.dumper = _Dumper
 
         # Bind a primitive converter
-        reg_primitive_converter = registry and registry._primitive_converter
-        if primitive_converter and reg_primitive_converter:
+        reg_implicit_converter = registry and registry._implicit_converter
+        if implicit_converter and reg_implicit_converter:
             raise ValueError(
                 "Both registry and parser specify"
                 " primitive converter, but only one can"
                 " be specified!"
             )
-        primitive_converter = primitive_converter or reg_primitive_converter
-        if primitive_converter is None:
-            primitive_converter = SensiblePrimitives()
+        implicit_converter = implicit_converter or reg_implicit_converter
+        if implicit_converter is None:
+            implicit_converter = StrictImplicitConverter()
 
-        primitive_converter.bind_loader(self.loader)
-        primitive_converter.bind_dumper(self.dumper)
+        implicit_converter.bind_loader(self.loader)
+        implicit_converter.bind_dumper(self.dumper)
 
         if registry is not None:
             for tag, typ, converter in registry:

--- a/blockyaml/types.py
+++ b/blockyaml/types.py
@@ -1,8 +1,9 @@
 try:
-    from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
+    from yaml import CSafeDumper as Dumper
+    from yaml import CSafeLoader as Loader
 except ImportError:
-    from yaml import Dumper, Loader
+    from yaml import SafeDumper as Dumper
+    from yaml import SafeLoader as Loader
 
 from yaml import CollectionNode, MappingNode, Node, ScalarNode, SequenceNode, YAMLError
 from yaml.constructor import ConstructorError as YAMLConstructorError

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -61,7 +61,7 @@ class TestBasic:
         """
         ) == [4, {"x": 0, "y": [1]}]
 
-    def test_primitive_checking(self):
+    def test_strict_implicit_converter(self):
         parser = Parser()
 
         with pytest.raises(YAMLConstructorError):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -25,6 +25,7 @@ from blockyaml import (
     YAMLDataclassExtraFieldsError,
     YAMLDataclassMissingFieldsError,
     YAMLParserError,
+    YAMLRepresenterError,
 )
 
 
@@ -61,6 +62,68 @@ class TestBasic:
         """
         ) == [4, {"x": 0, "y": [1]}]
 
+    def test_tags(self):
+        parser = Parser()
+
+        # Test a simple string converter
+        @parser.register(str, tag="!Upper")
+        class Capitalise(Converter):
+            def construct_scalar(self, loader, node):
+                return node.value.upper()
+
+        assert parser.parse_str("!Upper mYGarBaGeCASe") == "MYGARBAGECASE"
+
+        # Test converter registry
+        class Rect:
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+
+        @parser.register(Rect)
+        class RectConverter(Converter):
+            def construct_mapping(self, loader, node):
+                mapping = loader.construct_mapping(node, deep=True)
+                return Rect(x=mapping["x"], y=mapping["y"])
+
+            def represent_node(self, dumper, value):
+                return dumper.represent_mapping(self.tag, {"x": value.x, "y": value.y})
+
+        rectyaml = """
+        !Rect
+        x: 2
+        y: 4
+        """
+        rect = parser(Rect).parse_str(rectyaml)
+        assert rect.x == 2 and rect.y == 4
+        assert parser.dump_str(rect) == fixup(rectyaml)
+
+    def test_errors(self):
+        parser = Parser()
+
+        # Test explicit fall-throughs
+        class Registered:
+            ...
+
+        @parser.register(Registered, tag="!Registered")
+        class ConvertRegistered(Converter):
+            ...
+
+        with pytest.raises(YAMLConstructorError):
+            parser.parse_str("!Registered")
+
+        with pytest.raises(YAMLRepresenterError):
+            parser.dump_str(Registered())
+
+        # Test implicit fall throughs
+        class Unregistered:
+            ...
+
+        with pytest.raises(YAMLConstructorError):
+            parser.parse_str("!Unregistered")
+
+        with pytest.raises(YAMLRepresenterError):
+            parser.dump_str(Unregistered())
+
     def test_strict_implicit_converter(self):
         parser = Parser()
 
@@ -82,16 +145,8 @@ class TestBasic:
         with pytest.raises(YAMLConstructorError):
             parser.parse_str("!.html")
 
-    def test_tags(self):
+    def test_dataclass_converter(self):
         parser = Parser()
-
-        # Test a simple string converter
-        @parser.register(str, tag="!Upper")
-        class Capitalise(Converter):
-            def construct_scalar(self, loader, node):
-                return node.value.upper()
-
-        assert parser.parse_str("!Upper mYGarBaGeCASe") == "MYGARBAGECASE"
 
         # Test a dataclass converter
         @parser.register(DataclassConverter)
@@ -148,27 +203,3 @@ class TestBasic:
             parser(Date).parse_str("hello")
 
         assert isinstance(parser(Date).parse_str(dateyaml), Date)
-
-        # Test converter registry
-        class Rect:
-            def __init__(self, x: int, y: int):
-                self.x = x
-                self.y = y
-
-        @parser.register(Rect)
-        class RectConverter(Converter):
-            def construct_mapping(self, loader, node):
-                mapping = loader.construct_mapping(node, deep=True)
-                return Rect(x=mapping["x"], y=mapping["y"])
-
-            def represent_node(self, dumper, value):
-                return dumper.represent_mapping(self.tag, {"x": value.x, "y": value.y})
-
-        rectyaml = """
-        !Rect
-        x: 2
-        y: 4
-        """
-        rect = parser(Rect).parse_str(rectyaml)
-        assert rect.x == 2 and rect.y == 4
-        assert parser.dump_str(rect) == fixup(rectyaml)


### PR DESCRIPTION
Renamed primitive-converter to implicit-converter as it more accurately reflects what happens behind the scenes

Switch to using SafeLoader/SafeDumper - it was an oversight that we weren't previously.

Replaced NotImplementedErrors with useful errors and added unittests for them

